### PR TITLE
Use relative paths instead of Pkg.dir()

### DIFF
--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -15,7 +15,7 @@ function save(file::String, mime::MIME"text/html", doc::Metadata; mathjax = fals
     end
 
     # copy static files
-    src = joinpath(Pkg.dir("Lexicon"), "static")
+    src = joinpath(dirname(@__FILE__), "..", "..", "static")
     dst = joinpath(dirname(file), "static")
     isdir(dst) || mkpath(dst)
     for file in readdir(src)


### PR DESCRIPTION
`Pkg.dir()` won't work if Lexicon is installed outside the standard package location, so use relative paths instead to access other files in the package. See https://github.com/JuliaLang/julia/issues/8679#issuecomment-75796502