### PR TITLE
don't import Markdown in 0.4

### DIFF
--- a/src/Lexicon.jl
+++ b/src/Lexicon.jl
@@ -1,6 +1,8 @@
 module Lexicon
 
-import Markdown
+if VERSION < v"0.4-"
+    import Markdown
+end
 
 import Docile.Interface:
 

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -106,7 +106,9 @@ function doctest(modname::Module)
         isa(docs(entry), Docs{:md}) || continue # Markdown is the only supported format.
         count = 0
         for block in parsed(docs(entry)).content
-            if isa(block, Markdown.BlockCode)
+            # support older version of Markdown
+            Code = try Markdown.Code catch Markdown.BlockCode end
+            if isa(block, Code)
                 count += 1
                 try
                     if endswith(block.code, "\n") # skip code block with trailing newline


### PR DESCRIPTION
fixes #28

There's still one issue with using help e.g.
```
julia> import Lexicon

help?> Lexicon  # expect to print README
search: Lexicon

INFO: Parsing documentation for Docile.Interface.
INFO: Parsing documentation for Lexicon.
INFO: Parsing documentation for Docile.
```

Note: actually also `[text][ref]` syntax isn't supported yet, and I was getting an EOF error with your Lexicon's readme file (will see if I can reproduce...).