### PR TITLE
RFC: Exclude non-exported documentation

### DIFF
--- a/docs/api/Lexicon.md
+++ b/docs/api/Lexicon.md
@@ -18,7 +18,7 @@ doctest(Lexicon)
 
 
 **source:**
-[Lexicon/src/doctest.jl:101](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/doctest.jl#L101)
+[Lexicon/src/doctest.jl:101](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/doctest.jl#L101)
 
 ---
 
@@ -29,7 +29,7 @@ individual entry if several different ones are found.
 
 
 **source:**
-[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L184)
+[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L184)
 
 ---
 
@@ -40,17 +40,21 @@ individual entry if several different ones are found.
 
 
 **source:**
-[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L184)
+[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L184)
 
 ---
 
-#### save(file::AbstractString, modulename::Module)
+#### save(file::String, modulename::Module)
 Write the documentation stored in `modulename` to the specified `file`
 in the format guessed from the file's extension.
 
 If MathJax support is required then the optional keyword argument
 `mathjax::Bool` may be given. MathJax uses `\(...\)` for in-line maths
 and `\[...\]` or `$$...$$` for display equations.
+
+To exclude documentation for non-exported objects, the keyword argument
+`include_internal::Bool` should be set to `false`. This is only supported 
+for `markdown`.
 
 Currently supported formats: `HTML`, and `markdown`.
 
@@ -97,11 +101,11 @@ The documentation will be available from
 
 
 **source:**
-[Lexicon/src/render.jl:58](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/render.jl#L58)
+[Lexicon/src/render.jl:62](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/render.jl#L62)
 
 ---
 
-#### Lexicon.EachEntry
+#### EachEntry
 Iterator type for Metadata Entries with sorting options
 
 **Constructors**
@@ -149,7 +153,7 @@ res = [v.data[:source][2] for (k,v) in EachEntry(d)]
 
 
 **source:**
-[Lexicon/src/filtering.jl:131](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/filtering.jl#L131)
+[Lexicon/src/filtering.jl:131](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/filtering.jl#L131)
 
 ---
 
@@ -190,7 +194,7 @@ run(q)
 query(args...)
 
 **source:**
-[Lexicon/src/query.jl:116](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L116)
+[Lexicon/src/query.jl:116](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L116)
 
 ## Internal
 ---
@@ -199,11 +203,11 @@ query(args...)
 Basic text importance scoring.
 
 **source:**
-[Lexicon/src/query.jl:207](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L207)
+[Lexicon/src/query.jl:207](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L207)
 
 ---
 
-#### filter(docs::Docile.Metadata)
+#### filter(docs::Metadata)
 Filter Metadata based on categories or file source
 
 **Arguments**
@@ -240,11 +244,11 @@ entries( filter(d, files = ["types.jl"]) )
 
 
 **source:**
-[Lexicon/src/filtering.jl:39](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/filtering.jl#L39)
+[Lexicon/src/filtering.jl:39](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/filtering.jl#L39)
 
 ---
 
-#### filter(f::Function, docs::Docile.Metadata)
+#### filter(f::Function, docs::Metadata)
 Filter Metadata based on a function
 
 **Arguments**
@@ -272,19 +276,19 @@ end
 
 
 **source:**
-[Lexicon/src/filtering.jl:78](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/filtering.jl#L78)
+[Lexicon/src/filtering.jl:78](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/filtering.jl#L78)
 
 ---
 
-#### Lexicon.Match
+#### Match
 An entry and the set of all objects that are linked to it.
 
 **source:**
-[Lexicon/src/query.jl:43](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L43)
+[Lexicon/src/query.jl:43](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L43)
 
 ---
 
-#### Lexicon.Query
+#### Query
 Holds the parsed user query.
 
 **Fields:**
@@ -296,14 +300,14 @@ Holds the parsed user query.
 
 
 **source:**
-[Lexicon/src/query.jl:23](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L23)
+[Lexicon/src/query.jl:23](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L23)
 
 ---
 
-#### Lexicon.QueryResults
+#### QueryResults
 Stores the matching entries resulting from running a query.
 
 **source:**
-[Lexicon/src/query.jl:53](https://github.com/MichaelHatherly/Lexicon.jl/tree/33e504ea950e1fae5889c80264f92d7965e8923d/src/query.jl#L53)
+[Lexicon/src/query.jl:53](https://github.com/MichaelHatherly/Lexicon.jl/tree/1a1fc56751c2a8900e3c7c4f41342ecf8a44513e/src/query.jl#L53)
 
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -12,6 +12,10 @@ If MathJax support is required then the optional keyword argument
 `mathjax::Bool` may be given. MathJax uses `\(...\)` for in-line maths
 and `\[...\]` or `$$...$$` for display equations.
 
+To exclude documentation for non-exported objects, the keyword argument
+`include_internal::Bool` should be set to `false`. This is only supported 
+for `markdown`.
+
 Currently supported formats: `HTML`, and `markdown`.
 
 **MkDocs**
@@ -55,9 +59,9 @@ The documentation will be available from
 `https://USER_NAME.github.io/PACKAGE_NAME/FILE_PATH.html`.
 
 """
-function save(file::String, modulename::Module; mathjax = false)
+function save(file::String, modulename::Module; mathjax = false, include_internal = true)
     mime = MIME("text/$(strip(last(splitext(file)), '.'))")
-    save(file, mime, documentation(modulename); mathjax = mathjax)
+    save(file, mime, documentation(modulename); mathjax = mathjax, include_internal = include_internal)
 end
 
 const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -6,7 +6,8 @@ end
 
 ## General HTML rendering - static pages and IJulia –––––––––––––––––––––––––––––––––––––
 
-function save(file::String, mime::MIME"text/html", doc::Metadata; mathjax = false)
+function save(file::String, mime::MIME"text/html", doc::Metadata; mathjax = false, include_internal = true)
+    include_internal || throw(ArgumentError("include_internal should be true for html"))
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -6,12 +6,12 @@ end
 
 ## General markdown rendering ------------------------–––––––––––––––––––––––––––––––––––
 
-function save(file::String, mime::MIME"text/md", doc::Metadata; mathjax = false)
+function save(file::String, mime::MIME"text/md", doc::Metadata; mathjax = false, include_internal = true)
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
         info("writing documentation to $(file)")
-        writemime(f, mime, doc; mathjax = mathjax)
+        writemime(f, mime, doc; mathjax = mathjax, include_internal = include_internal)
     end
 end
 
@@ -32,7 +32,7 @@ function writemime(io::IO, mime::MIME"text/md", manual::Manual)
     end
 end
 
-function writemime(io::IO, mime::MIME"text/md", doc::Metadata; mathjax = false)
+function writemime(io::IO, mime::MIME"text/md", doc::Metadata; mathjax = false, include_internal = true)
     header(io, mime, doc)
 
     # Root may be a file or directory. Get the dir.
@@ -58,19 +58,19 @@ function writemime(io::IO, mime::MIME"text/md", doc::Metadata; mathjax = false)
             end
         end
         println(io)
-        writemime(io, mime, ents)
+        writemime(io, mime, ents, include_internal = include_internal)
     end
     footer(io, mime, doc; mathjax = mathjax)
 end
 
-function writemime(io::IO, mime::MIME"text/md", ents::Entries)
+function writemime(io::IO, mime::MIME"text/md", ents::Entries; include_internal = true)
     exported = Entries()
     internal = Entries()
 
     for (modname, obj, ent) in ents.entries
         isexported(modname, obj) ?
             push!(exported, modname, obj, ent) :
-            push!(internal, modname, obj, ent)
+            include_internal && push!(internal, modname, obj, ent)
     end
 
     if !isempty(exported.entries)


### PR DESCRIPTION
This pull request adds an `include_internal` keyword to `save`, which defaults to `true`. If `false`, for `markdown` output, non-exported objects are not included. For `html` output, if `include_internal` is `false`, an error is thrown, since the html output does not differentiate between exported and internal docs. 