### PR TITLE
Fixes the example: file not found: docs/api/Lexicon.md

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -34,7 +34,7 @@ The documentation for this package was created in the following manner.
 All commands are run from the top-level folder in the package.
 
 ```julia
-save("docs/api/lexicon.md", Lexicon)
+save("docs/api/Lexicon.md", Lexicon)
 run(`mkdocs build`)
 
 ```


### PR DESCRIPTION
in `mkdocs.yml` it is specified with capital `L`.  https://github.com/MichaelHatherly/Lexicon.jl/blob/master/mkdocs.yml#L10