### PR TITLE
Optional `markdown` style configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### v0.1.4dev
+
+* Adds for `markdown` optional style configuration.
+
 ### v0.1.3
 
 * Use relative paths instead of `Pkg.dir()`.

--- a/docs/api/Lexicon.md
+++ b/docs/api/Lexicon.md
@@ -18,7 +18,7 @@ doctest(Lexicon)
 
 
 **source:**
-[Lexicon/src/doctest.jl:101](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/doctest.jl#L101)
+[Lexicon.jl/src/doctest.jl:101](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/doctest.jl#L101)
 
 ---
 
@@ -29,7 +29,7 @@ individual entry if several different ones are found.
 
 
 **source:**
-[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L184)
+[Lexicon.jl/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L184)
 
 ---
 
@@ -40,7 +40,7 @@ individual entry if several different ones are found.
 
 
 **source:**
-[Lexicon/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L184)
+[Lexicon.jl/src/query.jl:184](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L184)
 
 ---
 
@@ -53,10 +53,45 @@ If MathJax support is required then the optional keyword argument
 and `\[...\]` or `$$...$$` for display equations.
 
 To exclude documentation for non-exported objects, the keyword argument
-`include_internal::Bool` should be set to `false`. This is only supported 
+`include_internal::Bool` should be set to `false`. This is only supported
 for `markdown`.
 
 Currently supported formats: `HTML`, and `markdown`.
+
+**Markdown optional configuration**
+
+The format `markdown` accepts an optional configurtion dictionary which can be used to adjust
+the style of defined items.
+
+* Below are the DEFAULT_MDSTYLE, HTAGS (Valid Header Tags), STYLETAGS (Valid Style Tags)
+
+```julia
+DEFAULT_MDSTYLE = Dict{ASCIIString, ASCIIString}([
+  ("header"         , "#"),
+  ("objname"        , "####"),
+  ("meta"           , "**"),
+  ("exported"       , "##"),
+  ("internal"       , "##"),
+])
+
+HTAGS = ["#", "##", "###", "####", "#####", "######"]
+STYLETAGS = ["", "*", "**"]
+```
+
+EXAMPLE USAGE:
+
+```julia
+MDSTYLE = Dict{ASCIIString, ASCIIString}([
+  ("header"         , "#"),
+  ("objname"        , "###"),
+  ("meta"           , "*"),
+  ("exported"       , "##"),
+  ("internal"       , "##"),
+])
+
+save("docs/api/Lexicon.md", Lexicon, MDSTYLE)
+
+```
 
 **MkDocs**
 
@@ -74,7 +109,7 @@ The documentation for this package was created in the following manner.
 All commands are run from the top-level folder in the package.
 
 ```julia
-save("docs/api/lexicon.md", Lexicon)
+save("docs/api/Lexicon.md", Lexicon)
 run(`mkdocs build`)
 
 ```
@@ -101,7 +136,7 @@ The documentation will be available from
 
 
 **source:**
-[Lexicon/src/render.jl:62](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/render.jl#L62)
+[Lexicon.jl/src/render.jl:97](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/render.jl#L97)
 
 ---
 
@@ -153,7 +188,7 @@ res = [v.data[:source][2] for (k,v) in EachEntry(d)]
 
 
 **source:**
-[Lexicon/src/filtering.jl:131](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/filtering.jl#L131)
+[Lexicon.jl/src/filtering.jl:131](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/filtering.jl#L131)
 
 ---
 
@@ -194,7 +229,7 @@ run(q)
 query(args...)
 
 **source:**
-[Lexicon/src/query.jl:116](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L116)
+[Lexicon.jl/src/query.jl:116](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L116)
 
 ## Internal
 ---
@@ -203,7 +238,7 @@ query(args...)
 Basic text importance scoring.
 
 **source:**
-[Lexicon/src/query.jl:207](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L207)
+[Lexicon.jl/src/query.jl:207](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L207)
 
 ---
 
@@ -244,7 +279,7 @@ entries( filter(d, files = ["types.jl"]) )
 
 
 **source:**
-[Lexicon/src/filtering.jl:39](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/filtering.jl#L39)
+[Lexicon.jl/src/filtering.jl:39](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/filtering.jl#L39)
 
 ---
 
@@ -276,7 +311,7 @@ end
 
 
 **source:**
-[Lexicon/src/filtering.jl:78](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/filtering.jl#L78)
+[Lexicon.jl/src/filtering.jl:78](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/filtering.jl#L78)
 
 ---
 
@@ -284,7 +319,7 @@ end
 An entry and the set of all objects that are linked to it.
 
 **source:**
-[Lexicon/src/query.jl:43](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L43)
+[Lexicon.jl/src/query.jl:43](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L43)
 
 ---
 
@@ -300,7 +335,7 @@ Holds the parsed user query.
 
 
 **source:**
-[Lexicon/src/query.jl:23](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L23)
+[Lexicon.jl/src/query.jl:23](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L23)
 
 ---
 
@@ -308,6 +343,6 @@ Holds the parsed user query.
 Stores the matching entries resulting from running a query.
 
 **source:**
-[Lexicon/src/query.jl:53](https://github.com/MichaelHatherly/Lexicon.jl/tree/e6ccf9f4a12e75fe062282c0756ff4a0bcd359e7/src/query.jl#L53)
+[Lexicon.jl/src/query.jl:53](https://github.com/MichaelHatherly/Lexicon.jl/tree/f711322ecce8403b019a0a1d6bfff78d61c88a10/src/query.jl#L53)
 
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -13,10 +13,46 @@ If MathJax support is required then the optional keyword argument
 and `\[...\]` or `$$...$$` for display equations.
 
 To exclude documentation for non-exported objects, the keyword argument
-`include_internal::Bool` should be set to `false`. This is only supported 
+`include_internal::Bool` should be set to `false`. This is only supported
 for `markdown`.
 
 Currently supported formats: `HTML`, and `markdown`.
+
+**Markdown optional configuration**
+
+The format `markdown` accepts an optional configurtion dictionary which can be used to adjust
+the style of defined items.
+
+* Below are the DEFAULT_MDSTYLE, HTAGS (Valid Header Tags), STYLETAGS (Valid Style Tags)
+
+```julia
+DEFAULT_MDSTYLE = Dict{ASCIIString, ASCIIString}([
+  ("header"         , "#"),
+  ("objname"        , "####"),
+  ("meta"           , "**"),
+  ("exported"       , "##"),
+  ("internal"       , "##"),
+])
+
+HTAGS = ["#", "##", "###", "####", "#####", "######"]
+STYLETAGS = ["", "*", "**"]
+```
+
+EXAMPLE USAGE:
+
+```julia
+using Lexicon
+MDSTYLE = Dict{ASCIIString, ASCIIString}([
+  ("header"         , "#"),
+  ("objname"        , "###"),
+  ("meta"           , "*"),
+  ("exported"       , "##"),
+  ("internal"       , "##"),
+])
+
+save("docs/api/Lexicon.md", Lexicon, MDSTYLE)
+
+```
 
 **MkDocs**
 
@@ -34,6 +70,7 @@ The documentation for this package was created in the following manner.
 All commands are run from the top-level folder in the package.
 
 ```julia
+using Lexicon
 save("docs/api/Lexicon.md", Lexicon)
 run(`mkdocs build`)
 
@@ -62,6 +99,12 @@ The documentation will be available from
 function save(file::String, modulename::Module; mathjax = false, include_internal = true)
     mime = MIME("text/$(strip(last(splitext(file)), '.'))")
     save(file, mime, documentation(modulename); mathjax = mathjax, include_internal = include_internal)
+end
+
+function save(file::String, modulename::Module, conf::Dict{ASCIIString, ASCIIString}; mathjax = false, include_internal = true)
+    mime = MIME("text/$(strip(last(splitext(file)), '.'))")
+    mime != MIME("text/md") && error(" Customary `conf` dictionaries are only supported for `markdown`: Got mime: $mime")
+    save(file, mime, documentation(modulename), conf; mathjax = mathjax, include_internal = include_internal)
 end
 
 const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -1,17 +1,43 @@
 ## Docs-specific rendering ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
-function writemime(io::IO, mime::MIME"text/md", docs::Docs{:md})
+function writemime(io::IO, mime::MIME"text/md", docs::Docs{:md}, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     println(io, docs.data)
 end
 
 ## General markdown rendering ------------------------–––––––––––––––––––––––––––––––––––
 
-function save(file::String, mime::MIME"text/md", doc::Metadata; mathjax = false, include_internal = true)
+const DEFAULT_MDSTYLE = Dict{ASCIIString, ASCIIString}([
+  ("header"         , "#"),
+  ("objname"        , "####"),
+  ("meta"           , "**"),
+  ("exported"       , "##"),
+  ("internal"       , "##"),
+])
+
+const HTAGS = ["#", "##", "###", "####", "#####", "######"]
+const STYLETAGS = ["", "*", "**"]
+
+print_help(io::IO, cv::ASCIIString, item) = cv in HTAGS ? println(io, "$cv $item") : println(io, cv, item, cv)
+
+function validate(mdstyle::Dict{ASCIIString, ASCIIString})
+    reg_keys = ["header", "objname", "meta", "exported", "internal"]
+    length(keys(mdstyle)) != length(reg_keys) && error(
+            "`mdstyle` expected number of keys: $(length(reg_keys))  Got: $(length(keys(mdstyle)))")
+    vaild_tags = vcat(HTAGS,STYLETAGS)
+    for (k, v) in mdstyle
+        !(k in reg_keys) && error("Invalid mdstyle key:  `$k`. Valid keys: [$(join(reg_keys, ", "))].")
+        !(v in vaild_tags) && error("Invalid mdstyle value:  `$v`. Valid values: [$(join(vaild_tags, ", "))].")
+    end
+end
+
+function save(file::String, mime::MIME"text/md", doc::Metadata, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE;
+                                                                                mathjax = false, include_internal = true)
+    validate(mdstyle)
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
         info("writing documentation to $(file)")
-        writemime(f, mime, doc; mathjax = mathjax, include_internal = include_internal)
+        writemime(f, mime, doc, mdstyle; mathjax = mathjax, include_internal = include_internal)
     end
 end
 
@@ -26,14 +52,15 @@ end
 
 length(ents::Entries) = length(ents.entries)
 
-function writemime(io::IO, mime::MIME"text/md", manual::Manual)
+function writemime(io::IO, mime::MIME"text/md", manual::Manual, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     for page in pages(manual)
-        writemime(io, mime, docs(page))
+        writemime(io, mime, docs(page), mdstyle)
     end
 end
 
-function writemime(io::IO, mime::MIME"text/md", doc::Metadata; mathjax = false, include_internal = true)
-    header(io, mime, doc)
+function writemime(io::IO, mime::MIME"text/md", doc::Metadata, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE;
+                                                                                mathjax = false, include_internal = true)
+    header(io, mime, doc, mdstyle)
 
     # Root may be a file or directory. Get the dir.
     rootdir = isfile(root(doc)) ? dirname(root(doc)) : root(doc)
@@ -58,12 +85,13 @@ function writemime(io::IO, mime::MIME"text/md", doc::Metadata; mathjax = false, 
             end
         end
         println(io)
-        writemime(io, mime, ents, include_internal = include_internal)
+        writemime(io, mime, ents, mdstyle; include_internal = include_internal)
     end
     footer(io, mime, doc; mathjax = mathjax)
 end
 
-function writemime(io::IO, mime::MIME"text/md", ents::Entries; include_internal = true)
+function writemime(io::IO, mime::MIME"text/md", ents::Entries,
+            mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE; include_internal = true)
     exported = Entries()
     internal = Entries()
 
@@ -74,53 +102,56 @@ function writemime(io::IO, mime::MIME"text/md", ents::Entries; include_internal 
     end
 
     if !isempty(exported.entries)
-        println(io, "## Exported")
+        print_help(io, mdstyle["exported"], "Exported")
         for (modname, obj, ent) in exported.entries
-            writemime(io, mime, modname, obj, ent)
+            writemime(io, mime, modname, obj, ent, mdstyle)
         end
     end
     if !isempty(internal.entries)
-        println(io, "## Internal")
+        print_help(io, mdstyle["internal"], "Internal")
         for (modname, obj, ent) in internal.entries
-            writemime(io, mime, modname, obj, ent)
+            writemime(io, mime, modname, obj, ent, mdstyle)
         end
     end
 end
 
-function writemime{category}(io::IO, mime::MIME"text/md", modname, obj, ent::Entry{category})
+function writemime{category}(io::IO, mime::MIME"text/md", modname, obj, ent::Entry{category},
+                                    mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     objname = writeobj(obj, ent)
     ## print(io, "<div class='category'>[$(category)] &mdash; </div> ")
-    println(io, "---\n\n#### $(objname)")
-    writemime(io, mime, docs(ent))
+    println(io, "---\n")
+    print_help(io, mdstyle["objname"], objname)
+    writemime(io, mime, docs(ent), mdstyle)
     ## println(io, "**Details:**")
     println(io)
     for k in sort(collect(keys(ent.data)))
-        println(io, "**", k, ":**")
-        writemime(io, mime, Meta{k}(ent.data[k]))
+        print_help(io, mdstyle["meta"], "$k:")
+        writemime(io, mime, Meta{k}(ent.data[k]), mdstyle)
         println(io)
     end
 end
 
-function writemime(io::IO, mime::MIME"text/md", md::Meta)
+
+function writemime(io::IO, mime::MIME"text/md", md::Meta, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     println(io, md.content)
 end
 
-function writemime(io::IO, mime::MIME"text/md", m::Meta{:parameters})
+function writemime(io::IO, mime::MIME"text/md", m::Meta{:parameters}, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     for (k, v) in m.content
         println(io, k)
     end
-    writemime(io, mime, v)
+    writemime(io, mime, v, mdstyle)
 end
 
-function writemime(io::IO, ::MIME"text/md", m::Meta{:source})
+function writemime(io::IO, ::MIME"text/md", m::Meta{:source}, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
     path = last(split(m.content[2], r"v[\d\.]+(/|\\)"))
     println(io, "[$(path):$(m.content[1])]($(url(m)))")
 end
 
-function header(io::IO, ::MIME"text/md", doc::Metadata)
-    println(io, "# $(doc.modname)")
+function header(io::IO, ::MIME"text/md", doc::Metadata, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE)
+    print_help(io, mdstyle["header"], doc.modname)
 end
 
-function footer(io::IO, ::MIME"text/md", doc::Metadata; mathjax = false)
+function footer(io::IO, ::MIME"text/md", doc::Metadata, mdstyle::Dict{ASCIIString, ASCIIString} = DEFAULT_MDSTYLE; mathjax = false)
     println(io, "")
 end


### PR DESCRIPTION
#39

* Optional `markdown` style configuration.
* Stripped trailing spaces.
* Added: `using Lexicon` to Example to make it selfcontained.
  - a shame it renders to italic: see issues #40, mkdocs/mkdocs#411
  - e.g.: theme `mkdocs` seems to have not this issue

* Added entry to NEWS

I did not add any additional tests. 