### PR TITLE
Cleaning up md.jl

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -137,9 +137,11 @@ The documentation will be available from
 """
 function save(file::String, modulename::Module; args...)
     config = Config(; args...)
-    mime = MIME("text/$(strip(last(splitext(file)), '.'))")
-    save(file, mime, documentation(modulename), config)
+    strip(last(splitext(file)), '.') == "html"              ?
+        savehtml(file, documentation(modulename), config) :
+        savemd(file, documentation(modulename), config)
 end
+
 
 const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -137,9 +137,8 @@ The documentation will be available from
 """
 function save(file::String, modulename::Module; args...)
     config = Config(; args...)
-    strip(last(splitext(file)), '.') == "html"              ?
-        savehtml(file, documentation(modulename), config) :
-        savemd(file, documentation(modulename), config)
+    mime = MIME("text/$(strip(last(splitext(file)), '.'))")
+    save(file, mime, documentation(modulename), config)
 end
 
 

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -6,13 +6,13 @@ end
 
 ## General HTML rendering - static pages and IJulia –––––––––––––––––––––––––––––––––––––
 
-function savehtml(file::String, doc::Metadata, config::Config)
+function save(file::String, mime::MIME"text/html", doc::Metadata, config::Config)
     config.include_internal || throw(ArgumentError("`config` option `include_internal` must be true for html"))
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
         info("writing documentation to $(file)")
-        writemime(f, MIME("text/html"), doc, config)
+        writemime(f, mime, doc, config)
     end
 
     # copy static files

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -6,13 +6,13 @@ end
 
 ## General HTML rendering - static pages and IJulia –––––––––––––––––––––––––––––––––––––
 
-function save(file::String, mime::MIME"text/html", doc::Metadata, config::Config)
+function savehtml(file::String, doc::Metadata, config::Config)
     config.include_internal || throw(ArgumentError("`config` option `include_internal` must be true for html"))
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
         info("writing documentation to $(file)")
-        writemime(f, mime, doc, config)
+        writemime(f, MIME("text/html"), doc, config)
     end
 
     # copy static files

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -97,7 +97,7 @@ function writemd(io::IO, md::Meta)
     println(io, md.content)
 end
 
-function writemd(io::IO,  m::Meta{:source})
+function writemd(io::IO, m::Meta{:source})
     path = last(split(m.content[2], r"v[\d\.]+(/|\\)"))
     println(io, "[$(path):$(m.content[1])]($(url(m)))")
 end

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -94,7 +94,6 @@ function writemd{category}(io::IO, modname, obj, ent::Entry{category}, config::C
 end
 
 function writemd(io::IO, md::Meta)
-    
     println(io, md.content)
 end
 

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -9,7 +9,7 @@ print_help(io::IO, cv::ASCIIString, item) = cv in MDHTAGS            ?
                                             println(io, "$cv $item") :
                                             println(io, cv, item, cv)
 
-function savemd(file::String, doc::Metadata, config::Config)
+function save(file::String, mime::MIME"text/md", doc::Metadata, config::Config)
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
@@ -53,7 +53,6 @@ function writemd(io::IO, doc::Metadata, config::Config)
         println(io)
         writemd(io, ents, config)
     end
-    footermd(io)
 end
 
 function writemd(io::IO, ents::Entries, config::Config)
@@ -105,26 +104,3 @@ end
 function headermd(io::IO, doc::Metadata, config::Config)
     print_help(io, config.mdstyle_header, doc.modname)
 end
-
-function footermd(io::IO)
-    println(io, "")
-end
-
-
-#  =============== TODO: if no Problems arise delete this below
-#length(ents::Entries) = length(ents.entries)  # TODO: if no Problems arise delete this
-
-
-#function writemd(io::IO, mime::MIME"text/md", manual::Manual)
-#    println(""">>SEEMS IT GETS NOT CALLED: writemd(io::IO, mime::MIME"text/md", manual::Manual) is this done in line 36??""")
-#    for page in pages(manual)
-#        writemd(io, MIME("text/md"), docs(page))
-#    end
-#end
-#function writemd(io::IO, mime::MIME"text/md", m::Meta{:parameters})
-#    for (k, v) in m.content
-#        println(io, k)
-#    end
-#    println("""=====2 """, @which writemd(io, MIME("text/md"), v))
-#    writemd(io, MIME("text/md"), v)
-#end


### PR DESCRIPTION
This is the first part of: https://github.com/MichaelHatherly/Lexicon.jl/issues/54
I thought it is easier for you to merge if there are smaller PR so I split it.

This runs successful `Pkg.test("Lexicon")` and `Pkg.test("Docile")` as well `both build.jl`.

I hope there are not too many issues - but it looks nice and clean now.

I now julia is famous for multiple dispatching but it still has to look up the correct sig.
and it is a bit hard for outsiders to see which method is internally called.

```
function foo(a,b,c)
    funcwith100methods(a,b)  # very hard to find out which one without inserting a @which
end
```

Anyway: I left most of it as it was just renamed the internal `save` to `savehtml`, `savemd` and the internal md.jl `writemime` to `writemd` - and clean out quite a bit.