### PR TITLE
Adds function relpath

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -98,6 +98,52 @@ function url(m::Meta{:source})
     end
 end
 
+## Utilities
+# Return the index of the last non-empty string value in "A" (determined by `!isempty(A[i])`).
+function findlast{S <: AbstractString}(A::Array{S,1})
+    i = length(A)
+    while i > 0
+        isempty(A[i]) || break
+        i -= 1
+    end
+    return i
+end
+
+# Return a relative filepath to path either from the current directory or from an optional start directory.
+# This is a path computation: the filesystem is not accessed to confirm the existence or nature of path or startpath.
+# Inspired by python's relpath
+function relpath(path::ByteString, startpath::ByteString = ".")
+    isempty(path) && throw(ArgumentError("`path` must be specified"))
+    isempty(startpath) && throw(ArgumentError("`startpath` must be specified"))
+    curdir = "."
+    pardir = ".."
+    path == startpath && return curdir
+
+    path_arr  = split(abspath(path),      Base.path_separator_re)
+    start_arr = split(abspath(startpath), Base.path_separator_re)
+
+    i = 0
+    while i < min(length(path_arr), length(start_arr))
+        i += 1
+        if path_arr[i] != start_arr[i]
+            i -= 1
+            break
+        end
+    end
+
+    pathpart = join(path_arr[i+1:findlast(path_arr)], Base.path_separator)
+    prefix_num = findlast(start_arr) - i - 1
+    if prefix_num >= 0
+        prefix = pardir * Base.path_separator
+        relpath_ = isempty(pathpart)                                      ?
+            (prefix^prefix_num) * pardir                                  :
+            (prefix^prefix_num) * pardir * Base.path_separator * pathpart
+    else
+        relpath_ = pathpart
+    end
+    return isempty(relpath_) ? curdir :  relpath_
+end
+
 ## Format-specific rendering ------------------------------------------------------------
 
 include("render/plain.jl")

--- a/test/facts/rendering.jl
+++ b/test/facts/rendering.jl
@@ -45,4 +45,78 @@ facts("Rendering.") do
         end
     end
 
+    context("Testin relpath.") do
+        filepaths = ["/home/user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+                        "/home/user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+                        "/home/user/.julia/v0.4/Docile/docs/api/Docile.md",
+                        "/home/user/dir_withendsep/",
+                        "/home/dir2_withendsep/",
+                        "/home/test.md",
+                        "/home",
+                        # Special cases
+                        "/",
+                        "/home///"
+                    ]
+        startpaths = ["/home/user/.julia/v0.4/Lexicon/docs/api/genindex.md",
+                        "/multi_docs/genindex.md",
+                        "/home/user/dir_withendsep/",
+                        "/home/dir2_withendsep/",
+                        "/home/test.md",
+                        "/home",
+                        # Special cases
+                        "/",
+                        "/home///"
+                    ]
+
+        # generated with python's relpath
+        relpath_expected_results = ["../Lexicon.md",
+            "../../home/user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "../.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "../user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "../user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+             "user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "home/user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "user/.julia/v0.4/Lexicon/docs/api/Lexicon.md",
+            "../lib/file1.md", "../../home/user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "../.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "../user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "../user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "home/user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+             "user/.julia/v0.4/Lexicon/docs/api/lib/file1.md",
+            "../../../../Docile/docs/api/Docile.md",
+            "../../home/user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "../.julia/v0.4/Docile/docs/api/Docile.md",
+            "../user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "../user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "home/user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "user/.julia/v0.4/Docile/docs/api/Docile.md",
+            "../../../../../../dir_withendsep", "../../home/user/dir_withendsep", ".",
+            "../user/dir_withendsep", "../user/dir_withendsep", "user/dir_withendsep",
+            "home/user/dir_withendsep", "user/dir_withendsep",
+            "../../../../../../../dir2_withendsep", "../../home/dir2_withendsep",
+            "../../dir2_withendsep", ".", "../dir2_withendsep", "dir2_withendsep",
+            "home/dir2_withendsep", "dir2_withendsep", "../../../../../../../test.md",
+            "../../home/test.md", "../../test.md", "../test.md", ".", "test.md", "home/test.md",
+            "test.md", "../../../../../../..", "../../home", "../..", "..", "..", ".", "home",
+            ".", "../../../../../../../..", "../..", "../../..", "../..", "../..", "..", ".",
+            "..", "../../../../../../..", "../../home", "../..", "..", "..", ".", "home", "."
+            ]
+
+        idx = 0
+        for filep in filepaths
+            for startp in startpaths
+                res = Lexicon.relpath(filep, startp)
+                idx += 1
+                @fact res => relpath_expected_results[idx] "Excpected: $(relpath_expected_results[idx])"
+            end
+        end
+
+        # Additional cases
+        @fact_throws ArgumentError Lexicon.relpath("/home/user/dir_withendsep/", "")
+        @fact_throws ArgumentError Lexicon.relpath("", "/home/user/dir_withendsep/")
+
+    end
+
 end


### PR DESCRIPTION
This is needed later to calculate the relative path for the Index Page
to the different API pages.  Issue #43

I thought maybe smaller PR are easier to merge.

* I had to redo it: the last one had some problems in certain situations.
* I wrote an test case using results generated with python's relpath (expecting that this should work ok)

helper function: findlast: I know one could write it a bit shorter with a for loop - but in my tests such while loops are about 10% faster and I keep it for other things too.
If you prefer it different no problem if you want to rewrite it.

I'm not sure if this Tests will work on Windows - maybe I need to change the input files to use different pathsep.


