### PR TITLE
New API-Index just for discussion WIP

### DIFF
--- a/docs/build.jl
+++ b/docs/build.jl
@@ -20,11 +20,16 @@ cd(dirname(@__FILE__)) do
         filename = joinpath(api_directory, "$(module_name(m)).md")
         try
             save(filename, m)
+            # Save individual API-Index
+            savegenindex(joinpath(api_directory, "$(module_name(m))_genindex.md"))
         catch err
             println(err)
             exit(1)
         end
     end
+    # Save all API-Index: this does not work togehter with individual: just one of them can be used because
+    # calling `savegenindex` will on purpose clear the collected data
+    savegenindex(joinpath(api_directory, "genindex.md"))
 
     # Add a reminder not to edit the generated files.
     open(joinpath(api_directory, "README.md"), "w") do f

--- a/src/Lexicon.jl
+++ b/src/Lexicon.jl
@@ -29,6 +29,7 @@ export
     @query,
     query,
     save,
+    savegenindex,
 
     doctest,
     failed,

--- a/src/docs/save.md
+++ b/src/docs/save.md
@@ -27,6 +27,10 @@ characters or 0 to 2 `*` characters.
 * `mdstyle_exported` (default: `"##"`):  style for the "exported" documentation header.
 * `mdstyle_internal` (default: "##"):    style for the "internal" documentation header.
 
+* `md_genindex`      (default: `true`):  to disable markdown *API-Index Page* generation
+  the keyword argument `md_genindex = false` should be set.
+  To actually save the *API-Index* one has to use the `savegenindex` function.
+
 Any option can be user adjusted by passing keyword arguments to the `save` method.
 
 **Example:**

--- a/src/render.jl
+++ b/src/render.jl
@@ -17,6 +17,7 @@ type Config
     mdstyle_meta     :: ASCIIString
     mdstyle_exported :: ASCIIString
     mdstyle_internal :: ASCIIString
+    md_genindex      :: Bool
 
     const fields   = fieldnames(Config)
     const defaults = Dict{Symbol, Any}([
@@ -26,7 +27,8 @@ type Config
         (:mdstyle_objname  , "###"),
         (:mdstyle_meta     , "*"),
         (:mdstyle_exported , "##"),
-        (:mdstyle_internal , "##")
+        (:mdstyle_internal , "##"),
+        (:md_genindex      , true)
         ])
 
     function Config(; args...)
@@ -54,6 +56,21 @@ function save(file::String, modulename::Module; args...)
     config = Config(; args...)
     mime = MIME("text/$(strip(last(splitext(file)), '.'))")
     save(file, mime, documentation(modulename), config)
+end
+
+file"docs/savegenindex.md"
+function savegenindex(file::String; headerstyle::ASCIIString = "#",
+            modnamestyle::ASCIIString = "##", categorystyle::ASCIIString = "###")
+    # Validations
+    for (k, v) in [("headerstyle", headerstyle), ("modnamestyle", modnamestyle), 
+                                                ("categorystyle", categorystyle)]
+        v in vcat(MDHTAGS, MDSTYLETAGS) || 
+                    error("""Invalid mdstyle value: savegenindex-item `$k -> $v`.
+                            Valid values: [$(join(vcat(MDHTAGS, MDSTYLETAGS), ", "))].""")
+    end
+    mime = MIME("text/$(strip(last(splitext(file)), '.'))")
+    savegenindex(file, mime; headerstyle = headerstyle, modnamestyle = modnamestyle, 
+                                                        categorystyle = categorystyle)
 end
 
 const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -25,6 +25,11 @@ function save(file::String, mime::MIME"text/html", doc::Metadata, config::Config
     end
 end
 
+function savegenindex(file::String, mime::MIME"text/html"; headerstyle::ASCIIString = "#",
+                        modnamestyle::ASCIIString = "##", categorystyle::ASCIIString = "###")
+    error("The html format does currently not support saving of separate API-Index pages.)")
+end
+
 type Entries
     entries::Vector{(Module, Any, Entry)}
 end

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -10,12 +10,37 @@ print_help(io::IO, cv::ASCIIString, item) = cv in MDHTAGS            ?
                                             println(io, cv, item, cv)
 
 function save(file::String, mime::MIME"text/md", doc::Metadata, config::Config)
+    config.md_genindex && push!(MainAnchorRef.docfilepath, abspath(file))
     # Write the main file.
     isfile(file) || mkpath(dirname(file))
     open(file, "w") do f
         info("writing documentation to $(file)")
         writemd(f, doc, config)
     end
+end
+
+function savegenindex(file::String, mime::MIME"text/md"; headerstyle::ASCIIString = "#",
+                    modnamestyle::ASCIIString = "##", categorystyle::ASCIIString = "###")
+    # Write the index file.
+    isfile(file) || mkpath(dirname(file))
+    open(file, "w") do f
+        info("writing API-Index to $(file)")
+        writemd_idx(f)
+    end
+    clears_main_anchor_ref(MainAnchorRef)
+end
+
+# Collects Data needed for Anchor/LinkReferece
+type AnchorRef
+    docfilepath::Vector{String}
+
+    AnchorRef() = new(Vector{String}([]))
+end
+
+const MainAnchorRef = AnchorRef()
+
+function clears_main_anchor_ref(anchor_ref::AnchorRef)
+    anchor_ref.docfilepath = Vector{String}([])
 end
 
 type Entries
@@ -103,4 +128,10 @@ end
 
 function headermd(io::IO, doc::Metadata, config::Config)
     print_help(io, config.mdstyle_header, doc.modname)
+end
+
+## API-Index ----------------------------------------------------------------------------
+
+function writemd_idx(io::IO)
+    println(io, "This is still Work In Process")
 end


### PR DESCRIPTION
 Question: reference function #43 

Hi,

I thought I put up a early state discussion PR of the new idea for an API-Index because you did not like the previous too much ;)  https://github.com/MichaelHatherly/Lexicon.jl/pull/50#discussion-diff-28061552L27

Anyway here we go.

#### 1. 
I would like to avoid the user needing to push anything to a `indices` vector put do it internally.

Basic idea: have a global storage for collection of related data ect. e.g. `const MainAnchorRef = AnchorRef()`

* when the user calls: `save` with the option `md_genindex=true` (default) each file related api-index data is collected
* to actually save the API-Index one needs to call: `savegenindex` which will do the final calculations (like relative path ect.) and write the API-Index file.
After that it will clear(reset the global `MainAnchorRef`)

This way it allows for multiple Modules within one API-Index (needed for Docile for e.g.)
as well as the option to write each individuale API-Index file.

See the additions to the build.jl for example.

#### 2.
I thought it might be more suitable to put the styling for the API-Idex into the  `savegenindex` function.

I added it first in our new `Config` but there is a theoretical problem that one uses for the `save` functions for  multiple modules different settings but in the end each API-Index page should have only one style.

But if you think it does not matter I can also move it back to `Config`