### PR TITLE
html_validation_fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### v0.1.8
+
+* Fix for `html` not passing validation issue #65.
+
 ### v0.1.7
 
 * Fix for changes in import behaviour.

--- a/src/docs/save.md
+++ b/src/docs/save.md
@@ -6,6 +6,8 @@ are `HTML` and `markdown`.
 
 *General Options*
 
+* `category_order` (default: `[:module, :function, :method, :type, :typealias, :macro, :global, :comment]`)
+  Categories  to include in the output in the defined order.
 * `include_internal` (default: `true`): To exclude documentation for non-exported objects,
   the keyword argument `include_internal = false` should be set. This is only supported for
   `markdown`.

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -1,8 +1,9 @@
 ## Various methods for filtering and sorting Metadata
 
+const CATEGORY_ORDER = [:module, :function, :method, :type, :typealias, :macro, :global]
 
 """
-Filter Metadata based on categories or file source
+Filter Metadata based on categories or file source.
 
 **Arguments**
 
@@ -39,18 +40,16 @@ entries( filter(d, files = ["types.jl"]) )
 function Base.filter(docs::Metadata; categories = CATEGORY_ORDER, files = String[])
     result = copy(docs)
     if length(files) > 0
-        filter!((k,v) -> any(x -> contains(v.data[:source][2], x), files),
-                result.entries)
+        filter!((k,v) -> any(x -> contains(v.data[:source][2], x), files), result.entries)
     end
     if length(categories) > 0
-        filter!((k,v) -> any(x -> category(v) == x, categories),
-                result.entries)
+        filter!((k,v) -> any(x -> category(v) == x, categories), result.entries)
     end
     result
 end
 
 """
-Filter Metadata based on a function
+Filter Metadata based on a function.
 
 **Arguments**
 
@@ -83,7 +82,7 @@ end
 
 
 """
-Iterator type for Metadata Entries with sorting options
+Iterator type for Metadata Entries with sorting options.
 
 **Constructors**
 
@@ -155,4 +154,3 @@ Base.length(x::EachEntry) = length(x.kidx)
 Base.start(x::EachEntry) = 1
 Base.done(x::EachEntry, state) = state == length(x.kidx)
 Base.next(x::EachEntry, state) = ((x.kidx[state], x.parent.entries[x.kidx[state]]), state + 1)
-

--- a/src/render.jl
+++ b/src/render.jl
@@ -7,11 +7,9 @@ const MDHTAGS = ["#", "##", "###", "####", "#####", "######"]
 const MDSTYLETAGS = ["", "*", "**"]
 
 type Config
-    # General Options
+    category_order   :: Vector{Symbol}
     include_internal :: Bool
-    # Html only Options
     mathjax          :: Bool
-    # MarkDown only Options
     mdstyle_header   :: ASCIIString
     mdstyle_objname  :: ASCIIString
     mdstyle_meta     :: ASCIIString
@@ -20,6 +18,8 @@ type Config
 
     const fields   = fieldnames(Config)
     const defaults = Dict{Symbol, Any}([
+        (:category_order    , [:module, :function, :method, :type,
+                               :typealias, :macro, :global, :comment]),
         (:include_internal , true),
         (:mathjax          , false),
         (:mdstyle_header   , "#"),
@@ -55,17 +55,6 @@ function save(file::String, modulename::Module; args...)
     mime = MIME("text/$(strip(last(splitext(file)), '.'))")
     save(file, mime, documentation(modulename), config)
 end
-
-type Entries
-    entries::Vector{@compat(Tuple{Module, Any, AbstractEntry})}
-end
-Entries() = Entries(@compat(Tuple{Module, Any, AbstractEntry})[])
-
-function push!(ents::Entries, modulename::Module, obj, ent::AbstractEntry)
-    push!(ents.entries, (modulename, obj, ent))
-end
-
-const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]
 
 # Dispatch container for metadata display.
 type Meta{keyword}

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -18,6 +18,15 @@ function save(file::String, mime::MIME"text/md", doc::Metadata, config::Config)
     end
 end
 
+type EntriesMD
+    entries::Vector{@compat(Tuple{Module, Any, AbstractEntry})}
+end
+EntriesMD() = EntriesMD(@compat(Tuple{Module, Any, AbstractEntry})[])
+
+function push!(ents::EntriesMD, modulename::Module, obj, ent::AbstractEntry)
+    push!(ents.entries, (modulename, obj, ent))
+end
+
 function writemd(io::IO, doc::Metadata, config::Config)
     headermd(io, doc, config)
 
@@ -34,8 +43,8 @@ function writemd(io::IO, doc::Metadata, config::Config)
     end
 
     if !isempty(index)
-        ents = Entries()
-        for k in CATEGORY_ORDER
+        ents = EntriesMD()
+        for k in config.category_order
             haskey(index, k) || continue
             for (s, obj) in index[k]
                 push!(ents, modulename(doc), obj, entries(doc)[obj])
@@ -46,9 +55,9 @@ function writemd(io::IO, doc::Metadata, config::Config)
     end
 end
 
-function writemd(io::IO, ents::Entries, config::Config)
-    exported = Entries()
-    internal = Entries()
+function writemd(io::IO, ents::EntriesMD, config::Config)
+    exported = EntriesMD()
+    internal = EntriesMD()
 
     for (modname, obj, ent) in ents.entries
         isexported(modname, obj) ?

--- a/test/facts/rendering.jl
+++ b/test/facts/rendering.jl
@@ -47,7 +47,7 @@ facts("Rendering.") do
     end
 
     if VERSION < v"0.4.0-dev+4393"
-        context("Testin relpath.") do
+        context("Testing relpath.") do
             filepaths = [
                 "$(sep)home$(sep)user$(sep).julia$(sep)v0.4$(sep)Lexicon$(sep)docs$(sep)api$(sep)Lexicon.md",
                 "$(sep)home$(sep)user$(sep).julia$(sep)v0.4$(sep)Lexicon$(sep)docs$(sep)api$(sep)lib$(sep)file1.md",


### PR DESCRIPTION
Fix for `html` not passing validation issue #65.

This does not address all possible cases and may fail in certain situations.
But it seems to me that it is still a good improvement over the current situation.


http://validator.w3.org/#validate_by_input

**CURRENT  SITUATION**

Lexicon html api:

    Errors found while checking this document as HTML5!
    Result: 	10 Errors, 2 warning(s) 

Docile html api:

    Errors found while checking this document as HTML5!
    Result: 	56 Errors, 2 warning(s) 

Docile.Interface html api:

    Errors found while checking this document as HTML5!
    Result: 	10 Errors, 2 warning(s) 

**AFTER FIX**

Lexicon html api:

    This document was successfully checked as HTML5!
    Result: 	Passed, 2 warning(s)

Docile html api:

    This document was successfully checked as HTML5!
    Result: 	Passed, 2 warning(s)

Docile.Interface html api:

    This document was successfully checked as HTML5!
    Result: 	Passed, 2 warning(s)
    
---

* This does not bother to produce nice id's. It is just a simple fix.
    http://www.w3.org/TR/html4/types.html#type-id
    
    ID and NAME tokens must begin with a letter ([A-Za-z]) and may be followed by any number of letters, 
    digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods (".").
    
* This does not  check for duplicate id names in case of special character replacements.

* uses an ugly workaround to address potential `definition names` with unicode

```julia
function 但它不是一个大()
end
```

* This does not address other potential errors like `id` generated for definitions which only differ
in `case` like:

```julia
function a()
end

function A()
end
```

http://www.w3schools.com/tags/att_global_id.asp

`id 	Specifies a unique id for the element. Naming rules:`

* Must contain at least one character
* Must not contain any space characters
* **In HTML, all values are case-insensitive**


Other Changes: 

* by default typealias are also included in the output
* changed String => AbstractString
