### PR TITLE
move_EntriesMD_to_render_jl_and_renames_them

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -49,6 +49,16 @@ type Config
     end
 end
 
+
+type Entries
+    entries::Vector{@compat(Tuple{Module, Any, AbstractEntry})}
+end
+Entries() = Entries(@compat(Tuple{Module, Any, AbstractEntry})[])
+
+function push!(ents::Entries, modulename::Module, obj, ent::AbstractEntry)
+    push!(ents.entries, (modulename, obj, ent))
+end
+
 file"docs/save.md"
 function save(file::AbstractString, modulename::Module; args...)
     config = Config(; args...)

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -18,15 +18,6 @@ function save(file::AbstractString, mime::MIME"text/md", doc::Metadata, config::
     end
 end
 
-type EntriesMD
-    entries::Vector{@compat(Tuple{Module, Any, AbstractEntry})}
-end
-EntriesMD() = EntriesMD(@compat(Tuple{Module, Any, AbstractEntry})[])
-
-function push!(ents::EntriesMD, modulename::Module, obj, ent::AbstractEntry)
-    push!(ents.entries, (modulename, obj, ent))
-end
-
 function writemd(io::IO, doc::Metadata, config::Config)
     headermd(io, doc, config)
 
@@ -43,7 +34,7 @@ function writemd(io::IO, doc::Metadata, config::Config)
     end
 
     if !isempty(index)
-        ents = EntriesMD()
+        ents = Entries()
         for k in config.category_order
             haskey(index, k) || continue
             for (s, obj) in index[k]
@@ -55,9 +46,9 @@ function writemd(io::IO, doc::Metadata, config::Config)
     end
 end
 
-function writemd(io::IO, ents::EntriesMD, config::Config)
-    exported = EntriesMD()
-    internal = EntriesMD()
+function writemd(io::IO, ents::Entries, config::Config)
+    exported = Entries()
+    internal = Entries()
 
     for (modname, obj, ent) in ents.entries
         isexported(modname, obj) ?


### PR DESCRIPTION
The idea is to move common useful function back into render.jl as this
is needed later by both: html and markdown (no point to duplicate code)

The `EntriesHtml` in html.jl will be later removed