### PR TITLE
updates `cp` to keep the previous behavour

### DIFF
--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -22,7 +22,7 @@ function save(file::AbstractString, mime::MIME"text/html", doc::Metadata, config
     isdir(dst) || mkpath(dst)
     for file in readdir(src)
         info("copying $(file) to $(dst)")
-        cp(joinpath(src, file), joinpath(dst, file))
+        cp(joinpath(src, file), joinpath(dst, file); remove_destination=true)
     end
 end
 


### PR DESCRIPTION
my new implementation of the `cp` function got merged
https://github.com/JuliaLang/julia/pull/10888

sets `remove_destination=true` otherwise if you rerun you get an:

```
ERROR: ArgumentError: 'static/custom.css' exists.
`remove_destination=true` is required to remove
'static/custom.css' before copying.
```