### PR TITLE
general implementation of new save API

### DIFF
--- a/docs/build.jl
+++ b/docs/build.jl
@@ -16,15 +16,12 @@ cd(dirname(@__FILE__)) do
     end
 
     # Generate and save the contents of docstrings as markdown files.
-    for m in modules
-        filename = joinpath(api_directory, "$(module_name(m)).md")
-        try
-            save(filename, m)
-        catch err
-            println(err)
-            exit(1)
-        end
+    index  = Index()
+    config = Config()
+    for mod in modules
+        update!(index, save("$(mod).md", mod, config))
     end
+    #save("index.md", index, config)
 
     # Add a reminder not to edit the generated files.
     open(joinpath(api_directory, "README.md"), "w") do f

--- a/src/Lexicon.jl
+++ b/src/Lexicon.jl
@@ -29,13 +29,15 @@ export
     @query,
     query,
     save,
+    update!,
 
     doctest,
     failed,
     passed,
     skipped,
     EachEntry,
-    Config
+    Config,
+    Index
 
 
 @document

--- a/src/docs/save.md
+++ b/src/docs/save.md
@@ -23,11 +23,26 @@ are `HTML` and `markdown`.
 Valid values for the `mdstyle_*` options listed below are either 1 to 6 `#`
 characters or 0 to 2 `*` characters.
 
-* `mdstyle_header`   (default: `"#"`):   style for the documentation header.
-* `mdstyle_objname`  (default: `"###"`): style for each documented object.
-* `mdstyle_meta`     (default: `"*"`):   style for the metadata section on each documentation entry.
-* `mdstyle_exported` (default: `"##"`):  style for the "exported" documentation header.
-* `mdstyle_internal` (default: "##"):    style for the "internal" documentation header.
+* `mdstyle_header`         (default: `"#"`):   style for the documentation header and *API-Index*
+  modules header.
+* `mdstyle_objname`        (default: `"####"`): style for each documented object.
+* `mdstyle_meta`           (default: `"*"`):   style for the metadata section on each
+  documentation entry.
+* `mdstyle_subheader`      (default: `"##"`):  style for the documentation and *API-Index* subheader.
+* `mdstyle_genindex_mod`   (default: `"##"`):  style for the *API-Index* module header.
+
+* `md_subheader`           (default: `:simple`): Valid options are ":skip, :simple, :category"
+
+    * `md_subheader=:simple`   adds documentation and *API-Index* subheaders "Exported" / "Internal".
+    * `md_subheader=:category` adds documentation and *API-Index* subheaders per category.
+    * `md_subheader=:skip`     adds no subheaders to the documentation and *API-Index* and can be used
+    for documentation which has only few entries.
+
+* `md_genindex_modprefix`  (default: `"MODULE: "`): This option sets for the *API-Index Page*
+  a "prefix" text before the modulename.
+  `md_genindex_module_prefix = ""` if only the modulename should be displayed.
+* `md_permalink`           (default: `true`):  Adds a **¶** a permalink to each definition.
+  To disable it the keyword argument `md_permalink = false` should be set.
 
 Any option can be user adjusted by passing keyword arguments to the `save` method.
 
@@ -35,7 +50,8 @@ Any option can be user adjusted by passing keyword arguments to the `save` metho
 
 ```julia
 using Lexicon
-save("Lexicon.md", Lexicon; include_internal = false, mdstyle_header = "###")
+config = Config(include_internal = true)
+save("docs/api/Lexicon.md", Lexicon, config);
 
 ```
 
@@ -56,7 +72,7 @@ commands are run from the top-level folder in the package.
 
 ```julia
 using Lexicon
-save("docs/api/Lexicon.md", Lexicon)
+save("docs/api/Lexicon.md", Lexicon, Config());
 run(`mkdocs build`)
 
 ```

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -58,13 +58,13 @@ function writemd(io::IO, ents::Entries, config::Config)
     end
 
     if !isempty(exported.entries)
-        print_help(io, config.mdstyle_exported, "Exported")
+        print_help(io, config.mdstyle_subheader, "Exported")
         for (modname, obj, ent) in exported.entries
             writemd(io, modname, obj, ent, config)
         end
     end
     if !isempty(internal.entries)
-        print_help(io, config.mdstyle_internal, "Internal")
+        print_help(io, config.mdstyle_subheader, "Internal")
         for (modname, obj, ent) in internal.entries
             writemd(io, modname, obj, ent, config)
         end

--- a/test/facts/rendering.jl
+++ b/test/facts/rendering.jl
@@ -38,10 +38,16 @@ facts("Rendering.") do
     end
 
     context("Saving static content.") do
+        index  = Index()
+        config = Config(include_internal = true)
         for modname in (Lexicon, Docile, Docile.Interface), ft in ("md", "html")
             dir = joinpath(tempdir(), randstring())
             f = joinpath(dir, "$(modname).$(ft)")
-            save(f, modname; mathjax = true)
+            save(f, modname, config; mathjax = true)
+            # TODO: update is not implemented for html
+            #update!(index, save("$(mod).md", mod, config))
+            # TODO: save index not implemented yet
+            #save(joinpath(dir, "index_$(modname).$(ft)"), index, config)
             rm(dir, recursive = true)
         end
     end


### PR DESCRIPTION
At the moment I only use a normal `push!` instead of a special `update!` method you had in your proposel and use a normal Vector instead of  Index().

If you want we could change that at a later time - maybe it's better to get first the rest merged. I'm also not sure we need to use here something other than `push!`

Option adjustments should work as you suggested: just did not want to change any defaults for now.

The Api-Index saving I commented as it raises at the moment an Error: because it is not finally implemented.
```
index  = Index()
config = Config(md_permalink = true, other_option = "...")

for mod in modules
    update!(index, save("$(mod).md", mod, config; another_option = "...")
end

save("index.md", index, config; md_subheader=:category, extra_option = "...")
```