### PR TITLE
additional output filtering of metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Contributed by [@peter1000](https://github.com/peter1000)
 * Add optional output grouping by category.
 * Add optional API-Index pages for markdown output.
 * Add optional permalink for markdown output.
+* Add additional output filtering of metadata for markdown and html.
 
 ### v0.1.8
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -9,7 +9,7 @@ User adjustable Lexicon configuration.
 * `include_internal` (default: `true`): To exclude documentation for non-exported objects,
   the keyword argument `include_internal = false` should be set. This is only supported for
   `markdown`.
-* `metadata_order`      (default: `[:signature, :source]`)
+* `metadata_order`      (default: `[:source]`)
   Metadata to include in the output in the defined order. To not output any metadate
   `metadata_order = Symbol[]` should be set.
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -9,6 +9,9 @@ User adjustable Lexicon configuration.
 * `include_internal` (default: `true`): To exclude documentation for non-exported objects,
   the keyword argument `include_internal = false` should be set. This is only supported for
   `markdown`.
+* `metadata_order`      (default: `[:signature, :source]`)
+  Metadata to include in the output in the defined order. To not output any metadate
+  `metadata_order = Symbol[]` should be set.
 
 *HTML only options*
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -10,6 +10,7 @@ const MD_SUBHEADER_OPTIONS = [:skip, :simple, :category]
 file"docs/config.md"
 type Config
     category_order         :: Vector{Symbol}
+    metadata_order         :: Vector{Symbol}
     include_internal       :: Bool
     mathjax                :: Bool
     mdstyle_header         :: ASCIIString
@@ -24,6 +25,7 @@ type Config
     const defaults = Dict{Symbol, Any}([
         (:category_order         , [:module, :function, :method, :type,
                                     :typealias, :macro, :global, :comment]),
+        (:metadata_order         , [:signature, :source]),
         (:include_internal       , true),
         (:mathjax                , false),
         (:mdstyle_header         , "#"),

--- a/src/render.jl
+++ b/src/render.jl
@@ -25,7 +25,7 @@ type Config
     const defaults = Dict{Symbol, Any}([
         (:category_order         , [:module, :function, :method, :type,
                                     :typealias, :macro, :global, :comment]),
-        (:metadata_order         , [:signature, :source]),
+        (:metadata_order         , [:source]),
         (:include_internal       , true),
         (:mathjax                , false),
         (:mdstyle_header         , "#"),

--- a/src/render.jl
+++ b/src/render.jl
@@ -176,6 +176,18 @@ function save(file::AbstractString, index::Index, config::Config; args...)
 end
 save(file::AbstractString, index::Index; args...) = save(file, index, Config(); args...)
 
+# returns true if the Entry has metadata which should be included in the output
+function has_output_metadata(entry::Entry, config::Config)
+    output_metadata = false
+    for m in keys(metadata(entry))
+        if  m in config.metadata_order
+            output_metadata = true
+            break
+        end
+    end
+    return output_metadata
+end
+
 # Convert's a string to a valid html id
 function generate_html_id(s::AbstractString)
     # http://www.w3.org/TR/html4/types.html#type-id

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -88,15 +88,17 @@ function writehtml{category}(io::IO, modname, obj, ent::Entry{category}, config:
         end
         wrap(io, "div", "class='entry-body'") do
             writehtml(io, docs(ent))
-            wrap(io, "div", "class='entry-meta'") do
-                println(io, "<strong>Details:</strong>")
-                wrap(io, "table", "class='meta-table'") do
-                    for m in config.metadata_order
-                        if haskey(ent.data, m)
-                            wrap(io, "tr") do
-                                print(io, "<td><strong>", m, ":</strong></td>")
-                                wrap(io, "td") do
-                                    writehtml(io, Meta{m}(ent.data[m]))
+            if has_output_metadata(ent, config)
+                wrap(io, "div", "class='entry-meta'") do
+                    println(io, "<strong>Details:</strong>")
+                    wrap(io, "table", "class='meta-table'") do
+                        for m in config.metadata_order
+                            if haskey(ent.data, m)
+                                wrap(io, "tr") do
+                                    print(io, "<td><strong>", m, ":</strong></td>")
+                                    wrap(io, "td") do
+                                        writehtml(io, Meta{m}(ent.data[m]))
+                                    end
                                 end
                             end
                         end

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -65,20 +65,20 @@ function writehtml(io::IO, doc::Metadata, ents::EntriesHtml, config::Config)
                 end
             end
         end
-        writehtml(io,ents)
+        writehtml(io,ents, config)
     end
     return ents
 end
 
-function writehtml(io::IO, ents::EntriesHtml)
+function writehtml(io::IO, ents::EntriesHtml, config::Config)
     wrap(io, "div", "class='entries'") do
         for (modname, obj, ent) in ents.entries
-            writehtml(io, modname, obj, ent)
+            writehtml(io, modname, obj, ent, config)
         end
     end
 end
 
-function writehtml{category}(io::IO, modname, obj, ent::Entry{category})
+function writehtml{category}(io::IO, modname, obj, ent::Entry{category}, config::Config)
     wrap(io, "div", "class='entry'") do
         objname = writeobj(obj, ent)
         idname = "$(category)_" * generate_html_id(objname)
@@ -91,11 +91,13 @@ function writehtml{category}(io::IO, modname, obj, ent::Entry{category})
             wrap(io, "div", "class='entry-meta'") do
                 println(io, "<strong>Details:</strong>")
                 wrap(io, "table", "class='meta-table'") do
-                    for k in sort(collect(keys(ent.data)))
-                        wrap(io, "tr") do
-                            print(io, "<td><strong>", k, ":</strong></td>")
-                            wrap(io, "td") do
-                                writehtml(io, Meta{k}(ent.data[k]))
+                    for m in config.metadata_order
+                        if haskey(ent.data, m)
+                            wrap(io, "tr") do
+                                print(io, "<td><strong>", m, ":</strong></td>")
+                                wrap(io, "td") do
+                                    writehtml(io, Meta{m}(ent.data[m]))
+                                end
                             end
                         end
                     end

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -52,11 +52,13 @@ function writemd{category}(io::IO, modname, obj, ent::Entry{category},
                     string(objname, config.md_permalink ? " [¶](#$anchorname)" : ""))
     writemd(io, docs(ent))
     println(io)
-    for m in config.metadata_order
-        if haskey(ent.data, m)
-            println_mdstyle(io, config.mdstyle_meta, "$m:", false)
-            writemd(io, Meta{m}(ent.data[m]))
-            println(io)
+    if has_output_metadata(ent, config)
+        for m in config.metadata_order
+            if haskey(ent.data, m)
+                println_mdstyle(io, config.mdstyle_meta, "$m:", false)
+                writemd(io, Meta{m}(ent.data[m]))
+                println(io)
+            end
         end
     end
 end

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -52,10 +52,12 @@ function writemd{category}(io::IO, modname, obj, ent::Entry{category},
                     string(objname, config.md_permalink ? " [¶](#$anchorname)" : ""))
     writemd(io, docs(ent))
     println(io)
-    for k in sort(collect(keys(ent.data)))
-        println_mdstyle(io, config.mdstyle_meta, "$k:", false)
-        writemd(io, Meta{k}(ent.data[k]))
-        println(io)
+    for m in config.metadata_order
+        if haskey(ent.data, m)
+            println_mdstyle(io, config.mdstyle_meta, "$m:", false)
+            writemd(io, Meta{m}(ent.data[m]))
+            println(io)
+        end
     end
 end
 

--- a/src/render/plain.jl
+++ b/src/render/plain.jl
@@ -75,24 +75,29 @@ function print_signature(io::IO, object, entry)
     println(io, colorize(:default, writeobj(object, entry)))
 end
 
-function writemime(io::IO, mime::MIME"text/plain", entry::Entry)
+function writemime(io::IO, mime::MIME"text/plain", entry::Entry, config::Config = Config())
     # Parse docstring into AST and print it out.
     writemime(io, mime, docs(entry))
 
     # Print metadata if any is available
-    isempty(metadata(entry)) || println(io, colorize(:green, " Details:\n"))
-    for (k, v) in metadata(entry)
-        if isa(v, Vector)
-            println(io, "\t", k, ":")
-            for line in v
-                if isa(line, NTuple)
-                    println(io, "\t\t", colorize(:cyan, string(line[1])), ": ", line[2])
+    if has_output_metadata(entry, config)
+        println(io, colorize(:green, " Details:\n"))
+        for m in config.metadata_order
+            if haskey(entry.data, m)
+                v = entry.data[m]
+                if isa(v, Vector)
+                    println(io, "\t", m, ":")
+                    for line in v
+                        if isa(line, NTuple)
+                            println(io, "\t\t", colorize(:cyan, string(line[1])), ": ", line[2])
+                        else
+                            println(io, "\t\t", string(line))
+                        end
+                    end
                 else
-                    println(io, "\t\t", string(line))
+                    println(io, "\t", m, ": ", v)
                 end
             end
-        else
-            println(io, "\t", k, ": ", v)
         end
     end
 end


### PR DESCRIPTION
Add additional output filtering of metadata for `markdown and html`

* **First Advantage:** user can define exactely which of any metadata are in the final documentation
Also user can define the output order.

* **Second Advantage:** we could use the meta dictionary to store other not user specific data like the keyword arguments per entry and if needed set them on a blacklist.