### PR TITLE
Error not defined help

### DIFF
--- a/examples/simple_test/build.jl
+++ b/examples/simple_test/build.jl
@@ -21,12 +21,10 @@ mods  = [docs("### ``$(m)``", m) for m in [
  
 out = document(
     section(
-        :manual,
         pages...,
         title  = "Manual Pages",
         ),
     section(
-        :api,
         page(
             mods...,
             title  = "Function & Methods",

--- a/examples/simple_test/build.jl
+++ b/examples/simple_test/build.jl
@@ -4,7 +4,7 @@ import Lexicon.Elements: document, section, page, docs
  
 import Docile
  
-pages = [page("# $(ucfirst(f))", "$(f).md") for f in [
+pages = [page("# $(ucfirst(f))", "$(f).md", title = f) for f in [
              "introduction",
              "syntax",
              "metamacros"
@@ -37,6 +37,7 @@ out = document(
             title  = "Types",
             filter = obj -> isa(obj, DataType),
             ),
+        outname = "api"
         ),
     title = "Docile Documentation",
     )

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -63,7 +63,6 @@ end
 update!(n::Node{Page}, x::Union(AbstractString, Node{Docs})) = push!(n.children, x)
 update!(n::Node{Docs}, x::Union(AbstractString, Module))     = push!(n.children, x)
 update!(n::Node,       x::Dict)                              = merge!(n.data, x)
-update!(n::Node,       x::Symbol)                            = n.data[:id] = x
 
 update!{S, T}(n::Node{S}, t::T) = throw(ArgumentError("Can't add '$(T)' to '$(S)' node."))
 

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -49,6 +49,7 @@ docs(args...; kwargs...)    = (Docs,    args, config(kwargs))
 
 function build!{T}(node::Node{T}, args, kwargs)
     isempty(args) && throw(ArgumentError("Empty '$(T)'."))
+    isa(node, Node{Docs}) || haskey(kwargs, :outname) || getoutname(node, kwargs)
     for arg in args update!(node, arg) end
     update!(node, kwargs)
     node
@@ -71,6 +72,16 @@ setparent!(n::Node{Section},  x::Union(Node{Section}, Node{Page})) = x.parent = 
 setparent!(n::Node{Page},     x::Node{Docs})                       = x.parent = n
 
 setparent!{S, T}(n::Node{S}, x::Node{T}) = throw(ArgumentError("Can't nest '$(T)' in '$(S)'."))
+
+function getoutname{T}(node::Node{T}, d::Dict)
+    haskey(d, :title) || throw(ArgumentError("'$T' has no key 'title'."))
+    replace_chars = Set(Char[' ', '&', '-'])
+    io = IOBuffer()
+    for c in d[:title]
+        c in replace_chars ? write(io, "_") : write(io, lowercase(string(c)))
+    end
+    d[:outname] = takebuf_string(io)
+end
 
 ## Display methods. For debugging. ##
 

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -47,7 +47,8 @@ section(args...; kwargs...) = (Section, args, config(kwargs))
 page(args...; kwargs...)    = (Page,    args, config(kwargs))
 docs(args...; kwargs...)    = (Docs,    args, config(kwargs))
 
-function build!(node::Node, args, kwargs)
+function build!{T}(node::Node{T}, args, kwargs)
+    isempty(args) && throw(ArgumentError("Empty '$(T)'."))
     for arg in args update!(node, arg) end
     update!(node, kwargs)
     node

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -16,6 +16,11 @@ immutable Section  <: NodeT end
 immutable Page     <: NodeT end
 immutable Docs     <: NodeT end
 
+immutable EmptyNodeError    <: Exception msg :: AbstractString end
+immutable ChildTypeError    <: Exception msg :: AbstractString end
+immutable ParentTypeError   <: Exception msg :: AbstractString end
+immutable MissingKeyError   <: Exception msg :: AbstractString end
+
 type Node{T <: NodeT}
     children :: Vector
     data     :: Dict{Symbol, Any}
@@ -48,7 +53,7 @@ page(args...; kwargs...)    = (Page,    args, config(kwargs))
 docs(args...; kwargs...)    = (Docs,    args, config(kwargs))
 
 function build!{T}(node::Node{T}, args, kwargs)
-    isempty(args) && throw(ArgumentError("Empty '$(T)'."))
+    isempty(args) && throw(EmptyNodeError("Empty '$(T)'."))
     isa(node, Node{Docs}) || haskey(kwargs, :outname) || getoutname(node, kwargs)
     for arg in args update!(node, arg) end
     update!(node, kwargs)
@@ -64,16 +69,16 @@ update!(n::Node{Page}, x::Union(AbstractString, Node{Docs})) = push!(n.children,
 update!(n::Node{Docs}, x::Union(AbstractString, Module))     = push!(n.children, x)
 update!(n::Node,       x::Dict)                              = merge!(n.data, x)
 
-update!{S, T}(n::Node{S}, t::T) = throw(ArgumentError("Can't add '$(T)' to '$(S)' node."))
+update!{S, T}(n::Node{S}, t::T) = throw(ChildTypeError("Can't add '$(T)' to '$(S)' node."))
 
 setparent!(n::Node{Document}, x::Node{Section})                    = x.parent = n
 setparent!(n::Node{Section},  x::Union(Node{Section}, Node{Page})) = x.parent = n
 setparent!(n::Node{Page},     x::Node{Docs})                       = x.parent = n
 
-setparent!{S, T}(n::Node{S}, x::Node{T}) = throw(ArgumentError("Can't nest '$(T)' in '$(S)'."))
+setparent!{S, T}(n::Node{S}, x::Node{T}) = throw(ParentTypeError("Can't nest '$(T)' in '$(S)'."))
 
 function getoutname{T}(node::Node{T}, d::Dict)
-    haskey(d, :title) || throw(ArgumentError("'$T' has no key 'title'."))
+    haskey(d, :title) || throw(MissingKeyError("'$T' has no key 'title'."))
     replace_chars = Set(Char[' ', '&', '-'])
     io = IOBuffer()
     for c in d[:title]

--- a/test/Elements/facts.jl
+++ b/test/Elements/facts.jl
@@ -9,118 +9,20 @@ import Lexicon.Elements:
     Document,
     Section,
     Page,
-    Docs
+    Docs,
+    EmptyNodeError,
+    ChildTypeError,
+    ParentTypeError,
+    MissingKeyError
+
 
 facts("Elements.") do
 
-    context("Tuple construction.") do
+    context("Empty Nodes.") do
 
-        @fact section() => (Section, (), Dict{Symbol, Any}())
-        @fact page()    => (Page, (), Dict{Symbol, Any}())
-        @fact docs()    => (Docs, (), Dict{Symbol, Any}())
-
-        @fact section(section()) => (
-            Section,
-            ((Section, (), Dict{Symbol, Any}()),),
-            Dict{Symbol, Any}())
-
-        @fact section(page(), page()) => (
-            Section,
-            ((Page, (), Dict{Symbol, Any}()),
-             (Page, (), Dict{Symbol, Any}()),),
-            Dict{Symbol, Any}())
-
-        @fact section(section(page(docs()))) => (
-            Section,
-            ((Section,
-              ((Page,
-                ((Docs,
-                  (),
-                  Dict{Symbol, Any}()),),
-                Dict{Symbol, Any}()),),
-              Dict{Symbol, Any}()),),
-            Dict{Symbol, Any}())
-
-        @fact page("", docs(), docs()) => (
-            Page,
-            ("",
-             (Docs, (), Dict{Symbol, Any}()),
-             (Docs, (), Dict{Symbol, Any}()),),
-            Dict{Symbol, Any}())
-
-    end
-
-    context("Node construction.") do
-
-        @fact document() => Node{Document}()
-
-        @fact document(section()) => Node{Document}(
-            Any[Node{Section}()],
-            Dict{Symbol, Any}())
-
-        @fact document(a = 1) => Node{Document}(
-            Any[],
-            @compat(Dict{Symbol, Any}(:a => 1)))
-
-        @fact document(section(page(""))) => Node{Document}(
-            Any[Node{Section}(
-                    Any[Node{Page}(Any[""], Dict{Symbol, Any}())],
-                    Dict{Symbol, Any}())],
-            Dict{Symbol, Any}())
-
-        @fact document(section(page(docs("")))) => Node{Document}(
-            Any[Node{Section}(
-                    Any[Node{Page}(
-                            Any[Node{Docs}(
-                                    Any[""],
-                                    Dict{Symbol, Any}())],
-                            Dict{Symbol, Any}())],
-                    Dict{Symbol, Any}())],
-            Dict{Symbol, Any}())
-
-        @fact_throws ArgumentError document(page())
-        @fact_throws ArgumentError document(page(section()))
-        @fact_throws ArgumentError document(docs())
-        @fact_throws ArgumentError document(section(section(section(""))))
-        @fact_throws ArgumentError document(page(current_module()))
-        @fact_throws ArgumentError document(section(current_module()))
-
-    end
-
-    context("Display.") do
-
-        str_1 = """
-        document(
-            section(
-                page(
-                    docs(
-                        Lexicon,
-                    ),
-                    title = "",
-                ),
-                page(
-                    "a",
-                ),
-            ),
-            section(
-                page(
-                    "a",
-                ),
-            ),
-            section(
-                page(
-                    "a",
-                ),
-            ),
-            b = :a,
-        )
-        """
-
-        buf = IOBuffer()
-        writemime(buf, "text/plain", eval(parse(str_1)))
-        str_2 = takebuf_string(buf)
-
-        @fact strip(str_1) => strip(str_2)
+        @fact_throws EmptyNodeError document(section(page(outname = "p",), outname = "s"), outname = "d")
+        @fact_throws EmptyNodeError document(section(outname = "s"), outname = "d")
+        @fact_throws EmptyNodeError document(outname = "d")
 
     end
 


### PR DESCRIPTION
hi, 
maybe you can spot where I made a mistake.

I just wanted to try to add some specific Errors which seems all fine but in Fact test I get an error:

`UndefVarError: EmptyNodeError not defined`

---

if I do the first fact example in the REPL

```julia
julia> import Lexicon.Elements:

           document,
           section,
           page,
           docs,
           config,
           Node,
           Document,
           Section,
           Page,
           Docs,
           EmptyNodeError,
           ChildTypeError,
           ParentTypeError,
           MissingKeyError

julia> document(section(page(outname = "p",), outname = "s"), outname = "d")
ERROR: Lexicon.Elements.EmptyNodeError("Empty 'Lexicon.Elements.Page'.")
 in build! at /home/workerm/.julia/v0.4/Lexicon/src/Elements/Elements.jl:56
 in build! at /home/workerm/.julia/v0.4/Lexicon/src/Elements/Elements.jl:58 (repeats 2 times)
 in document at /home/workerm/.julia/v0.4/Lexicon/src/Elements/Elements.jl:49

julia> 


```

Thanks

Can be deleted after wards.