### PR TITLE
Fix URL error on Windows

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -251,6 +251,7 @@ function url(m::Meta{:source})
         root = cd(d) do # dir=d confuses --show-toplevel, apparently
             Pkg.Git.readchomp(`rev-parse --show-toplevel`)
         end
+        root = @windows? replace(root, "/", "\\") : root
         if startswith(file, root)
             commit = Pkg.Git.readchomp(`rev-parse HEAD`, dir=d)
             return "https://github.com/$u/tree/$commit/"*file[length(root)+2:end]*"#L$line"


### PR DESCRIPTION
The old code never encoded github urls because there was an error
in the detection of package roots based on different path
separators on Windows.