### PR TITLE
Fix 0.4 error, use keys to check in dict

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -137,7 +137,7 @@ function prepare_entries(idx::Dict{Symbol, Any}, ents::Entries, doc::Metadata, c
     pageanchors = Dict{Symbol, Dict{String, Int}}([])
     for k in config.category_order
         haskey(idx, k) || continue
-        k in pageanchors || (pageanchors[k] = Dict([]))
+        k in keys(pageanchors) || (pageanchors[k] = Dict())
         basenames = pageanchors[k]
         for (s, obj) in idx[k]
             ent = entries(doc)[obj]


### PR DESCRIPTION
The latest julia, baulks without this:
```
ERROR: LoadError: Associative collections only contain Pairs;
Either look for e.g. A=>B instead, or use the `keys` or `values`
function if you are looking for a key or value respectively.
```

---

Edit: There's also an independent (I assume) error:

```
ERROR: LoadError: LoadError: MethodError: `isless` has no method matching isless(::Set{Docile.Legacy.AbstractEntry}, ::Set{Docile.Legacy.AbstractEntry})
```