### PR TITLE
Run doctest for an entire module and its submodules.

### DIFF
--- a/src/Lexicon.jl
+++ b/src/Lexicon.jl
@@ -32,6 +32,7 @@ export
     update!,
 
     doctest,
+    run_doctests,
     failed,
     passed,
     skipped,

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -140,3 +140,19 @@ function runcode(block, modname)
         eval(sandbox, ex)
     end
 end
+
+"""Run doctests for every submodule of `m`. Usually this will be run before
+generating documentation.
+
+Returns true if the they run successfully, false is there was a test failure."""
+function run_doctests(m::Module)
+    for m in modules
+        failures = failed(doctest(m))
+        if !isempty(failures.results)
+            println("\nDoctests failed, aborting.\n")
+            display(failures)
+            return false  # Bail when doctests fail.
+        end
+    end
+    return true
+end


### PR DESCRIPTION
This is essentially copied from Docile's build.jl (IIRC), and seems pretty useful as a library function.

No doubt the method name could be better...
